### PR TITLE
Include the `TrapFrame` struct and eliminate dependency on `esp32c3-hal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,11 @@ edition = "2021"
 
 [dependencies]
 esp-println = { version = "0.2.1", optional = true, default-features = false }
-xtensa-lx-rt = { version = "0.13.0", optional = true }
 riscv = { version = "0.8.0", optional = true }
-esp32c3-hal = { package = "esp32c3-hal", git = "https://github.com/esp-rs/esp-hal.git", optional = true }
+xtensa-lx-rt = { version = "0.13.0", optional = true }
 
 [features]
-esp32c3 = [ "esp-println?/esp32c3", "riscv", "esp32c3-hal" ]
+esp32c3 = [ "esp-println?/esp32c3", "riscv" ]
 esp32 = [ "esp-println?/esp32", "xtensa-lx-rt/esp32" ]
 esp32s2 = [ "esp-println?/esp32s2", "xtensa-lx-rt/esp32s2" ]
 esp32s3 = [ "esp-println?/esp32s3", "xtensa-lx-rt/esp32s3" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ unsafe extern "C" fn __exception(
 
 #[cfg(all(feature = "exception-handler", target_arch = "riscv32"))]
 #[export_name = "ExceptionHandler"]
-fn exception_handler(context: &esp32c3_hal::interrupt::TrapFrame) -> ! {
+fn exception_handler(context: &arch::TrapFrame) -> ! {
     use esp_println::*;
 
     let mepc = riscv::register::mepc::read();

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -1,6 +1,45 @@
 use crate::MAX_BACKTRACE_ADRESSES;
 use core::arch::asm;
 
+/// Registers saved in trap handler
+#[doc(hidden)]
+#[allow(missing_docs)]
+#[derive(Debug, Default, Clone, Copy)]
+#[repr(C)]
+pub(crate) struct TrapFrame {
+    pub ra: usize,
+    pub t0: usize,
+    pub t1: usize,
+    pub t2: usize,
+    pub t3: usize,
+    pub t4: usize,
+    pub t5: usize,
+    pub t6: usize,
+    pub a0: usize,
+    pub a1: usize,
+    pub a2: usize,
+    pub a3: usize,
+    pub a4: usize,
+    pub a5: usize,
+    pub a6: usize,
+    pub a7: usize,
+    pub s0: usize,
+    pub s1: usize,
+    pub s2: usize,
+    pub s3: usize,
+    pub s4: usize,
+    pub s5: usize,
+    pub s6: usize,
+    pub s7: usize,
+    pub s8: usize,
+    pub s9: usize,
+    pub s10: usize,
+    pub s11: usize,
+    pub gp: usize,
+    pub tp: usize,
+    pub sp: usize,
+}
+
 /// Get an array of backtrace addresses.
 ///
 /// This needs `force-frame-pointers` enabled.


### PR DESCRIPTION
As discussed earlier, copies the `TrapFrame` struct from `esp32c3-hal` into this crate, eliminating the dependency.