### PR TITLE
lib: Pretty-print `PanicInfo`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,29 @@ pub mod arch;
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     use esp_println::*;
 
-    println!("{:?}", info);
+    println!(" ");
+
+    if let Some(location) = info.location() {
+        let (file, line, column) = (location.file(), location.line(), location.column());
+        println!("!! A panic occured in '{file}', at line {line}, column {column}");
+    } else {
+        println!("!! A panic occured at an unknown location");
+    }
+
+    println!(" ");
+
+    // See: https://github.com/rust-lang/rust/issues/66745
+    //if let Some(msg) = info.message() {
+    //    println!("  Message: {msg}");
+    //}
+
+    print!("  Payload: ");
+    if let Some(s) = info.payload().downcast_ref::<&str>() {
+        println!("{s}");
+    }
+
+    println!("Backtrace:");
+    println!(" ");
 
     let backtrace = crate::arch::backtrace();
     for e in backtrace {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     use esp_println::*;
 
     println!(" ");
+    println!(" ");
 
     if let Some(location) = info.location() {
         let (file, line, column) = (location.file(), location.line(), location.column());
@@ -22,17 +23,8 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     }
 
     println!(" ");
-
-    // See: https://github.com/rust-lang/rust/issues/66745
-    //if let Some(msg) = info.message() {
-    //    println!("  Message: {msg}");
-    //}
-
-    print!("  Payload: ");
-    if let Some(s) = info.payload().downcast_ref::<&str>() {
-        println!("{s}");
-    }
-
+    println!("{:#?}", info);
+    println!(" ");
     println!("Backtrace:");
     println!(" ");
 


### PR DESCRIPTION
instead of relying solely on the `Debug` trait for printing. Also add
some more space to the output, so the Panic is easily recognized between
application text and the backtrace.

Currently, accessing the panic `message` is an unstable feature in `core`, see this tracking issue: https://github.com/rust-lang/rust/issues/66745

So unless this lands, the current debug print actually contains more useful information than this PR...