### PR TITLE
Update xtensa-lx-rt to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"]
 
 [dependencies]
 esp-println = { version = "0.3.0", optional = true, default-features = false }
-riscv = { version = "0.8.0", optional = true }
-xtensa-lx-rt = { version = "0.13.0", optional = true }
+riscv = { version = "0.10.0", optional = true }
+xtensa-lx-rt = { version = "0.14.0", optional = true }
 
 [features]
 esp32c2 = ["esp-println?/esp32c2", "riscv"]


### PR DESCRIPTION
In order to prepare a small change in esp-hal ( https://github.com/esp-rs/xtensa-lx-rt/pull/50 ) we first need to update all its dependencies

When this is merged, we need to bump this crate's version and release it