### PR TITLE
Use `__user_exception` instead of `__exception`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 #[cfg(all(feature = "exception-handler", target_arch = "xtensa"))]
 #[no_mangle]
 #[link_section = ".rwtext"]
-unsafe extern "C" fn __exception(cause: arch::ExceptionCause, context: arch::Context) {
+unsafe fn __user_exception(cause: arch::ExceptionCause, context: arch::Context) {
     use esp_println::println;
 
     println!("\n\nException occured '{:?}'", cause);


### PR DESCRIPTION
In order to get rid of the annoying workaround in esp-hal targeting ESP32-S2 while using atomic-emulation this now uses `__user_exception` instead of `__exception`

The default implementation will call `__user_exception` from the default `__exception` handler so this hopefully won't break things.
Thankfully `xtensa-atomic-emulation-trap` will call `__user_exception` when it can't handle the exception