### PR TITLE
Add support for the ESP32-C6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chip: [esp32c2, esp32c3]
+        chip: [esp32c2, esp32c3, esp32c6]
         printer: ["print-rtt", "print-uart"]
         include:
           - chip: esp32c3
+            printer: "print-jtag-serial"
+          - chip: esp32c6
             printer: "print-jtag-serial"
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,25 @@ default-target = "riscv32imc-unknown-none-elf"
 features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"]
 
 [dependencies]
-esp-println = { version = "0.3.0", optional = true, default-features = false }
+esp-println = { version = "0.4.0", optional = true, default-features = false }
 
 [features]
+# You must enable exactly one of the below features to support the correct chip:
+esp32 = ["esp-println?/esp32"]
 esp32c2 = ["esp-println?/esp32c2"]
 esp32c3 = ["esp-println?/esp32c3"]
-esp32 = ["esp-println?/esp32"]
+esp32c6 = ["esp-println?/esp32c6"]
 esp32s2 = ["esp-println?/esp32s2"]
 esp32s3 = ["esp-println?/esp32s3"]
-panic-handler = ["esp-println"]
-exception-handler = ["esp-println"]
-print-uart = ["esp-println/uart"]
+
+# You must enable exactly one of the below features to enable the intended
+# communication method:
 print-jtag-serial = ["esp-println/jtag_serial"]
 print-rtt = ["esp-println/rtt"]
+print-uart = ["esp-println/uart"]
+
+# You may optionally enable one or more of the below features to provide
+# additional functionality:
+exception-handler = ["esp-println"]
+panic-handler = ["esp-println"]
 halt-cores = []

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # esp-backtrace - backtrace for ESP32 bare-metal
 
-Supports the ESP32, ESP32-C2, ESP32-C3, ESP32-S2, and ESP32-S3. Optional exception and panic handlers are included, both of which can be enabled via their respective features.
+Supports the ESP32, ESP32-C2/C3/C6, and ESP32-S2/S3. Optional exception and panic handlers are included, both of which can be enabled via their respective features.
 
 Please note that you **need** to force frame pointers (i.e. `"-C", "force-frame-pointers",` in your `.cargo/config.toml`)
 
@@ -19,6 +19,7 @@ When using this together with `esp-println` make sure to use the same output kin
 | esp32             | Target ESP32                                                         |
 | esp32c2           | Target ESP32-C2                                                      |
 | esp32c3           | Target ESP32-C3                                                      |
+| esp32c6           | Target ESP32-C6                                                      |
 | esp32s2           | Target ESP32-S2                                                      |
 | esp32s3           | Target ESP32-S3                                                      |
 | panic-handler     | Include a panic handler, will add `esp-println` as a dependency      |

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,41 @@
 fn main() {
+    // Ensure that only a single chip is specified.
     let chip_features = [
         cfg!(feature = "esp32"),
         cfg!(feature = "esp32c2"),
         cfg!(feature = "esp32c3"),
+        cfg!(feature = "esp32c6"),
         cfg!(feature = "esp32s2"),
         cfg!(feature = "esp32s3"),
     ];
 
-    if chip_features.iter().filter(|&&f| f).count() != 1 {
-        panic!("Exactly one chip must be enabled via its cargo feature");
+    match chip_features.iter().filter(|&&f| f).count() {
+        1 => {}
+        n => panic!("Exactly 1 chip must be enabled via its Cargo feature, {n} provided"),
+    };
+
+    // Ensure that only a single communication method is specified.
+    let method_features = [
+        cfg!(feature = "print-jtag-serial"),
+        cfg!(feature = "print-rtt"),
+        cfg!(feature = "print-uart"),
+    ];
+
+    match method_features.iter().filter(|&&f| f).count() {
+        1 => {}
+        n => panic!(
+            "Exactly 1 communication method must be enabled via its Cargo feature, {n} provided"
+        ),
+    }
+
+    // Ensure that, if the `print-jtag-serial` communication method feature is
+    // enabled, either the `esp32c3`, `esp32c6`, or `esp32s3` chip feature is
+    // enabled.
+    if cfg!(feature = "print-jtag-serial")
+        && !(cfg!(feature = "esp32c3") || cfg!(feature = "esp32c6") || cfg!(feature = "esp32s3"))
+    {
+        panic!(
+            "The `print-jtag-serial` feature is only supported by the ESP32-C3, ESP32-C6, and ESP32-S3"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,24 +116,45 @@ fn exception_handler(context: &arch::TrapFrame) -> ! {
     halt();
 }
 
+// Ensure that the address is in DRAM and that it is 16-byte aligned.
+//
+// Based loosely on the `esp_stack_ptr_in_dram` function from
+// `components/esp_hw_support/include/esp_memory_utils.h` in ESP-IDF.
+//
+// Address ranges can be found in `components/soc/$CHIP/include/soc/soc.h` as
+// `SOC_DRAM_LOW` and `SOC_DRAM_HIGH`.
 fn is_valid_ram_address(address: u32) -> bool {
-    #[cfg(any(feature = "esp32c2", feature = "esp32c3"))]
-    if !(0x38000000..=0x3fffffff).contains(&address) {
+    if (address & 0xF) != 0 {
         return false;
     }
 
     #[cfg(feature = "esp32")]
-    if !(0x3ff80000..=0x3fffffff).contains(&address) {
+    if !(0x3FFA_E000..=0x4000_0000).contains(&address) {
+        return false;
+    }
+
+    #[cfg(feature = "esp32c2")]
+    if !(0x3FCA_0000..=0x3FCE_0000).contains(&address) {
+        return false;
+    }
+
+    #[cfg(feature = "esp32c3")]
+    if !(0x3FC8_0000..=0x3FCE_0000).contains(&address) {
+        return false;
+    }
+
+    #[cfg(feature = "esp32c6")]
+    if !(0x4080_0000..=0x4088_0000).contains(&address) {
         return false;
     }
 
     #[cfg(feature = "esp32s2")]
-    if !(0x3ff9e000..=0x3fffffff).contains(&address) {
+    if !(0x3FFB_0000..=0x4000_0000).contains(&address) {
         return false;
     }
 
     #[cfg(feature = "esp32s3")]
-    if !(0x3fc80000..=0x3fffffff).contains(&address) {
+    if !(0x3FC8_8000..=0x3FD0_0000).contains(&address) {
         return false;
     }
 


### PR DESCRIPTION
Adds support for the ESP32-C6. Also corrects the `is_valid_ram_address` function, which I vaguely remember discussing with @bjoernQ some number of months ago 😁 

I did verify this on hardware, though did not test it very thoroughly.

Closes #12