### PR TITLE
Clarify that frame pointers are only required for RISC-V devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Supports the ESP32, ESP32-C2/C3/C6, ESP32-S2/S3 and ESP32H2. Optional exception and panic handlers are included, both of which can be enabled via their respective features.
 
-Please note that you **need** to force frame pointers (i.e. `"-C", "force-frame-pointers",` in your `.cargo/config.toml`)
+Please note that when targeting a RISC-V device, you **need** to force frame pointers (i.e. `"-C", "force-frame-pointers",` in your `.cargo/config.toml`); this is **not** required for Xtensa.
 
 You can get an array of backtrace addresses (currently limited to 10) via `arch::backtrace()` if
 you want to create a backtrace yourself (i.e. not using the panic or exception handler).


### PR DESCRIPTION
Closes #35