### PR TITLE
Rework backtrace reader into an iterator

### DIFF
--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -1,6 +1,6 @@
 use core::arch::asm;
 
-use crate::MAX_BACKTRACE_ADRESSES;
+use crate::Backtrace;
 
 /// Registers saved in trap handler
 #[doc(hidden)]
@@ -101,60 +101,31 @@ MTVAL=0x{:08x}
     }
 }
 
-/// Get an array of backtrace addresses.
+/// Get an iterator of backtrace addresses.
 ///
 /// This needs `force-frame-pointers` enabled.
-pub fn backtrace() -> [Option<usize>; MAX_BACKTRACE_ADRESSES] {
+#[inline(never)]
+pub fn backtrace() -> Backtrace {
     let fp = unsafe {
         let mut _tmp: u32;
         asm!("mv {0}, x8", out(reg) _tmp);
         _tmp
     };
 
-    backtrace_internal(fp, 2)
+    Backtrace::new(fp, 2)
 }
 
-pub(crate) fn backtrace_internal(
-    fp: u32,
-    suppress: i32,
-) -> [Option<usize>; MAX_BACKTRACE_ADRESSES] {
-    let mut result = [None; 10];
-    let mut index = 0;
-
-    let mut fp = fp;
-    let mut suppress = suppress;
-    let mut old_address = 0;
-    loop {
+impl Backtrace {
+    pub(crate) fn read_next_pc(&mut self) -> Option<u32> {
         unsafe {
-            let address = (fp as *const u32).offset(-1).read_volatile(); // RA/PC
-            fp = (fp as *const u32).offset(-2).read_volatile(); // next FP
+            let next = (self.fp as *const u32).offset(-1).read_volatile(); // RA/PC
 
-            if old_address == address {
-                break;
+            if next == 0 {
+                return None;
             }
 
-            old_address = address;
-
-            if address == 0 {
-                break;
-            }
-
-            if !crate::is_valid_ram_address(fp) {
-                break;
-            }
-
-            if suppress == 0 {
-                result[index] = Some(address as usize);
-                index += 1;
-
-                if index >= MAX_BACKTRACE_ADRESSES {
-                    break;
-                }
-            } else {
-                suppress -= 1;
-            }
+            self.fp = (self.fp as *const u32).offset(-2).read_volatile(); // next FP
+            Some(next)
         }
     }
-
-    result
 }

--- a/src/xtensa.rs
+++ b/src/xtensa.rs
@@ -1,4 +1,5 @@
-use crate::MAX_BACKTRACE_ADRESSES;
+use crate::Backtrace;
+
 use core::arch::asm;
 
 #[doc(hidden)]
@@ -234,68 +235,29 @@ F15=0x{:08x}
     }
 }
 
-/// Get an array of backtrace addresses.
-///
-pub fn backtrace() -> [Option<usize>; MAX_BACKTRACE_ADRESSES] {
+/// Get an iterator of backtrace addresses.
+#[inline(never)]
+pub fn backtrace() -> Backtrace {
     let sp = unsafe {
         let mut _tmp: u32;
         asm!("mov {0}, a1", out(reg) _tmp);
         _tmp
     };
 
-    backtrace_internal(sp, 1)
+    Backtrace::new(sp, 1)
 }
 
-pub(crate) fn sanitize_address(address: u32) -> u32 {
-    (address & 0x3fff_ffff) | 0x4000_0000
-}
+impl Backtrace {
+    pub(crate) fn read_next_pc(&mut self) -> Option<u32> {
+        fn sanitize_address(address: u32) -> u32 {
+            (address & 0x3fff_ffff) | 0x4000_0000
+        }
 
-pub(crate) fn backtrace_internal(
-    sp: u32,
-    suppress: i32,
-) -> [Option<usize>; MAX_BACKTRACE_ADRESSES] {
-    let mut result = [None; 10];
-    let mut index = 0;
-
-    let mut fp = sp;
-    let mut suppress = suppress;
-    let mut old_address = 0;
-
-    loop {
         unsafe {
-            let address = sanitize_address((fp as *const u32).offset(-4).read_volatile()); // RA/PC
-            fp = (fp as *const u32).offset(-3).read_volatile(); // next FP
-
-            if old_address == address {
-                break;
-            }
-
-            old_address = address;
-
-            if address == 0 {
-                break;
-            }
-
-            if !crate::is_valid_ram_address(fp) {
-                break;
-            }
-
-            if fp == 0 {
-                break;
-            }
-
-            if suppress == 0 {
-                result[index] = Some(address as usize);
-                index += 1;
-
-                if index >= MAX_BACKTRACE_ADRESSES {
-                    break;
-                }
-            } else {
-                suppress -= 1;
-            }
+            // RA/PC
+            let next = sanitize_address((self.fp as *const u32).offset(-4).read_volatile());
+            self.fp = (self.fp as *const u32).offset(-3).read_volatile(); // next FP
+            Some(next)
         }
     }
-
-    result
 }


### PR DESCRIPTION
This impl, if I didn't break RISC-V should be much more flexible than before: we can print more frames, and we don't immediately stop if we encounter a recursive function. Also, we can remove some duplicate code.