### PR TITLE
Add feature to exit with semihosting::process:abort()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"]
 
 [dependencies]
 esp-println = { version = "0.7.0", optional = true, default-features = false }
+semihosting = { version = "0.1.4", optional = true }
 
 [features]
 # You must enable exactly one of the below features to support the correct chip:
@@ -34,3 +35,4 @@ print-uart = ["esp-println/uart"]
 exception-handler = ["esp-println"]
 panic-handler = ["esp-println"]
 halt-cores = []
+semihosting = ["dep:semihosting"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ When using this together with `esp-println` make sure to use the same output kin
 | print-jtag-serial | Use JTAG-Serial to print messages\*                                  |
 | print-rtt         | Use RTT to print messages\*                                          |
 | halt-cores        | Halt both CPUs on ESP32 / ESP32-S3 in case of a panic or exception   |
+| semihosting       | Do not halt the core(s), instead do a semihosting::process::abort()  |
 
 \* _only used for panic and exception handlers_
 

--- a/build.rs
+++ b/build.rs
@@ -42,4 +42,12 @@ fn main() {
             "The `print-jtag-serial` feature is only supported by the ESP32-C3, ESP32-C6, ESP32-S3 and ESP32-H2 chips"
         );
     }
+
+    if cfg!(feature = "semihosting") && cfg!(feature = "halt-cores") {
+        panic!("The features semihosting + halt-cores are exclusive");
+    }
+
+    if cfg!(feature = "semihosting") && cfg!(target_arch = "xtensa") {
+        panic!("Semihosting is not supported on xtensa targets");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,9 +166,17 @@ fn is_valid_ram_address(address: u32) -> bool {
     true
 }
 
-#[cfg(any(
-    not(any(feature = "esp32", feature = "esp32s3")),
-    not(feature = "halt-cores")
+#[cfg(feature = "semihosting")]
+fn halt() -> ! {
+    semihosting::process::abort()
+}
+
+#[cfg(all(
+    not(feature = "semihosting"),
+    any(
+        not(any(feature = "esp32", feature = "esp32s3")),
+        not(feature = "halt-cores")
+    )
 ))]
 #[allow(unused)]
 fn halt() -> ! {


### PR DESCRIPTION
Useful to get defmt_test working on esp32 riscv. ( https://github.com/knurling-rs/defmt/pull/796)