### PR TITLE
Hint on detected stack-overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"]
 esp-println = { version = "0.7.0", optional = true, default-features = false }
 
 [features]
+default = [ "colors" ]
+
 # You must enable exactly one of the below features to support the correct chip:
 esp32 = ["esp-println?/esp32"]
 esp32c2 = ["esp-println?/esp32c2"]
@@ -34,3 +36,4 @@ print-uart = ["esp-println/uart"]
 exception-handler = ["esp-println"]
 panic-handler = ["esp-println"]
 halt-cores = []
+colors = []

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ When using this together with `esp-println` make sure to use the same output kin
 | print-uart        | Use UART to print messages\*                                         |
 | print-jtag-serial | Use JTAG-Serial to print messages\*                                  |
 | print-rtt         | Use RTT to print messages\*                                          |
+| colors            | Print messages in red\*                                              |
 | halt-cores        | Halt both CPUs on ESP32 / ESP32-S3 in case of a panic or exception   |
 
 \* _only used for panic and exception handlers_

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -1,6 +1,6 @@
 use core::arch::asm;
 
-use crate::MAX_BACKTRACE_ADRESSES;
+use crate::MAX_BACKTRACE_ADDRESSES;
 
 /// Registers saved in trap handler
 #[doc(hidden)]
@@ -104,7 +104,7 @@ MTVAL=0x{:08x}
 /// Get an array of backtrace addresses.
 ///
 /// This needs `force-frame-pointers` enabled.
-pub fn backtrace() -> [Option<usize>; MAX_BACKTRACE_ADRESSES] {
+pub fn backtrace() -> [Option<usize>; MAX_BACKTRACE_ADDRESSES] {
     let fp = unsafe {
         let mut _tmp: u32;
         asm!("mv {0}, x8", out(reg) _tmp);
@@ -117,7 +117,7 @@ pub fn backtrace() -> [Option<usize>; MAX_BACKTRACE_ADRESSES] {
 pub(crate) fn backtrace_internal(
     fp: u32,
     suppress: i32,
-) -> [Option<usize>; MAX_BACKTRACE_ADRESSES] {
+) -> [Option<usize>; MAX_BACKTRACE_ADDRESSES] {
     let mut result = [None; 10];
     let mut index = 0;
 
@@ -147,7 +147,7 @@ pub(crate) fn backtrace_internal(
                 result[index] = Some(address as usize);
                 index += 1;
 
-                if index >= MAX_BACKTRACE_ADRESSES {
+                if index >= MAX_BACKTRACE_ADDRESSES {
                     break;
                 }
             } else {

--- a/src/xtensa.rs
+++ b/src/xtensa.rs
@@ -1,4 +1,4 @@
-use crate::MAX_BACKTRACE_ADRESSES;
+use crate::MAX_BACKTRACE_ADDRESSES;
 use core::arch::asm;
 
 #[doc(hidden)]
@@ -236,7 +236,7 @@ F15=0x{:08x}
 
 /// Get an array of backtrace addresses.
 ///
-pub fn backtrace() -> [Option<usize>; MAX_BACKTRACE_ADRESSES] {
+pub fn backtrace() -> [Option<usize>; MAX_BACKTRACE_ADDRESSES] {
     let sp = unsafe {
         let mut _tmp: u32;
         asm!("mov {0}, a1", out(reg) _tmp);
@@ -253,7 +253,7 @@ pub(crate) fn sanitize_address(address: u32) -> u32 {
 pub(crate) fn backtrace_internal(
     sp: u32,
     suppress: i32,
-) -> [Option<usize>; MAX_BACKTRACE_ADRESSES] {
+) -> [Option<usize>; MAX_BACKTRACE_ADDRESSES] {
     let mut result = [None; 10];
     let mut index = 0;
 
@@ -288,7 +288,7 @@ pub(crate) fn backtrace_internal(
                 result[index] = Some(address as usize);
                 index += 1;
 
-                if index >= MAX_BACKTRACE_ADRESSES {
+                if index >= MAX_BACKTRACE_ADDRESSES {
                     break;
                 }
             } else {


### PR DESCRIPTION
In https://github.com/esp-rs/esp-hal/pull/1008 we added a way to easily detect stack overflow on C6/H2

This now shows a clear indication of what happened. It doesn't print a backtrace since the stack is trashed anyways.

Additionally this introduces a new (default) feature `colors` which makes panics and exceptions printed in red
