### PR TITLE
Version 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-backtrace"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Bare-metal backtrace support for ESP32"
 repository = "https://github.com/esp-rs/esp-backtrace"
@@ -12,7 +12,7 @@ features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"]
 
 [dependencies]
 esp-println = { version = "0.8.0", optional = true, default-features = false }
-defmt = { version = "0.3.5"}
+defmt = { version = "=0.3.5"}
 
 [features]
 default = [ "colors" ]


### PR DESCRIPTION
The latest version:

- Now hints at detected stack overflows
- Removed `rtt` feature
- Includes latest release of `esp-println`
- Adds support for `defmt`

Don't think we really need to do anything else, so should be good for a release after this I think.