### PR TITLE
Allow `defmt-espflash` without the `esp-println` defmt handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ print-uart = ["esp-println/uart"]
 
 # You may optionally enable one or more of the below features to provide
 # additional functionality:
-defmt-espflash = ["esp-println?/defmt-espflash"]
+defmt-espflash = []
 exception-handler = ["esp-println"]
 panic-handler = ["esp-println"]
 halt-cores = []


### PR DESCRIPTION
Rationale: In my application I am using the `UartSerialJtag` driver which conflicts with the `esp-println` usb serial printer. I have a custom `defmt` logger that forwards the logs into the `esp-hal` USB serial driver.

Any comment is welcome!

Alternative: Create another feature `defmt` that just enables the `defmt::error` stuff.