### PR TITLE
Feature clean-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         chip: [esp32c2, esp32c3, esp32c6, esp32h2]
-        printer: ["esp-println/print-uart"]
+        printer: ["esp-println/uart"]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         chip: [esp32, esp32s2, esp32s3]
-        printer: ["esp-println/print-uart"]
+        printer: ["esp-println/uart"]
     steps:
       - uses: actions/checkout@v3
       - uses: esp-rs/xtensa-toolchain@v1.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         chip: [esp32c2, esp32c3, esp32c6, esp32h2]
-        printer: ["print-uart"]
-        include:
-          - chip: esp32c3
-            printer: "print-jtag-serial"
-          - chip: esp32c6
-            printer: "print-jtag-serial"
-          - chip: esp32h2
-            printer: "print-jtag-serial"
+        printer: ["esp-println/print-uart"]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
@@ -44,10 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         chip: [esp32, esp32s2, esp32s3]
-        printer: ["print-uart"]
-        include:
-          - chip: esp32s3
-            printer: "print-jtag-serial"
+        printer: ["esp-println/print-uart"]
     steps:
       - uses: actions/checkout@v3
       - uses: esp-rs/xtensa-toolchain@v1.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           toolchain: nightly
           components: rust-src
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check -Zbuild-std=core --target=riscv32imc-unknown-none-elf --features=${{ matrix.chip }},panic-handler,exception-handler,${{ matrix.printer }}
+      - run: cargo check -Zbuild-std=core --target=riscv32imc-unknown-none-elf --features=${{ matrix.chip }},panic-handler,exception-handler,println,${{ matrix.printer }}
 
   check-xtensa:
     name: Check Xtensa
@@ -45,4 +45,4 @@ jobs:
           default: true
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check -Zbuild-std=core --target=xtensa-${{ matrix.chip }}-none-elf --features=${{ matrix.chip }},panic-handler,exception-handler,${{ matrix.printer }}
+      - run: cargo check -Zbuild-std=core --target=xtensa-${{ matrix.chip }}-none-elf --features=${{ matrix.chip }},panic-handler,exception-handler,println,${{ matrix.printer }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"
-features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"]
+features = ["esp32c3", "panic-handler", "exception-handler", "esp-println/uart"]
 
 [dependencies]
 esp-println = { version = "0.8.0", optional = true, default-features = false }
-defmt = { version = "=0.3.5"}
+defmt = { version = "=0.3.5", optional = true }
 
 [features]
 default = [ "colors" ]
@@ -26,15 +26,10 @@ esp32h2 = ["esp-println?/esp32h2"]
 esp32s2 = ["esp-println?/esp32s2"]
 esp32s3 = ["esp-println?/esp32s3"]
 
-# You must enable exactly one of the below features to enable the intended
-# communication method:
-print-jtag-serial = ["esp-println/jtag-serial"]
-print-uart = ["esp-println/uart"]
-
 # You may optionally enable one or more of the below features to provide
 # additional functionality:
-defmt-espflash = []
-exception-handler = ["esp-println"]
-panic-handler = ["esp-println"]
+defmt = [ "dep:defmt" ]
+exception-handler = ["dep:esp-println"]
+panic-handler = ["dep:esp-println"]
 halt-cores = []
 colors = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,15 @@ esp32h2 = ["esp-println?/esp32h2"]
 esp32s2 = ["esp-println?/esp32s2"]
 esp32s3 = ["esp-println?/esp32s3"]
 
+# Use esp-println
+println = [ "dep:esp-println" ]
+
+# Use defmt
+defmt = [ "dep:defmt" ]
+
 # You may optionally enable one or more of the below features to provide
 # additional functionality:
-defmt = [ "dep:defmt" ]
-exception-handler = ["dep:esp-println"]
-panic-handler = ["dep:esp-println"]
+exception-handler = []
+panic-handler = []
 halt-cores = []
 colors = []

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ you want to create a backtrace yourself (i.e. not using the panic or exception h
 
 When using the panic and/or exception handler make sure to include `use esp_backtrace as _;`.
 
-When using this together with `esp-println` make sure to use the same output kind for both dependencies.
-(Or don't specify the output for `esp-backtrace`)
-
 ## Features
 
 | Feature           | Description                                                          |
@@ -25,9 +22,7 @@ When using this together with `esp-println` make sure to use the same output kin
 | esp32h2           | Target ESP32-H2                                                      |
 | panic-handler     | Include a panic handler, will add `esp-println` as a dependency      |
 | exception-handler | Include an exception handler, will add `esp-println` as a dependency |
-| print-uart        | Use UART to print messages\*                                         |
-| print-jtag-serial | Use JTAG-Serial to print messages\*                                  |
-| defmt-espflash    | Use `defmt` logging to print messages\* (check [example](https://github.com/playfulFence/backtrace-defmt-example))                    |
+| defmt             | Use `defmt` logging to print messages\* (check [example](https://github.com/playfulFence/backtrace-defmt-example))                    |
 | colors            | Print messages in red\*                                              |
 | halt-cores        | Halt both CPUs on ESP32 / ESP32-S3 in case of a panic or exception   |
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ When using the panic and/or exception handler make sure to include `use esp_back
 | esp32h2           | Target ESP32-H2                                                      |
 | panic-handler     | Include a panic handler, will add `esp-println` as a dependency      |
 | exception-handler | Include an exception handler, will add `esp-println` as a dependency |
+| println           | Use `esp-println` to print messages                                  |
 | defmt             | Use `defmt` logging to print messages\* (check [example](https://github.com/playfulFence/backtrace-defmt-example))                    |
 | colors            | Print messages in red\*                                              |
 | halt-cores        | Halt both CPUs on ESP32 / ESP32-S3 in case of a panic or exception   |

--- a/build.rs
+++ b/build.rs
@@ -14,31 +14,4 @@ fn main() {
         1 => {}
         n => panic!("Exactly 1 chip must be enabled via its Cargo feature, {n} provided"),
     };
-
-    // Ensure that only a single communication method is specified.
-    let method_features = [
-        cfg!(feature = "print-jtag-serial"),
-        cfg!(feature = "print-uart"),
-    ];
-
-    match method_features.iter().filter(|&&f| f).count() {
-        1 => {}
-        n => panic!(
-            "Exactly 1 communication method must be enabled via its Cargo feature, {n} provided"
-        ),
-    }
-
-    // Ensure that, if the `print-jtag-serial` communication method feature is
-    // enabled, either the `esp32c3`, `esp32c6`, or `esp32s3` chip feature is
-    // enabled.
-    if cfg!(feature = "print-jtag-serial")
-        && !(cfg!(feature = "esp32c3")
-            || cfg!(feature = "esp32c6")
-            || cfg!(feature = "esp32s3")
-            || cfg!(feature = "esp32h2"))
-    {
-        panic!(
-            "The `print-jtag-serial` feature is only supported by the ESP32-C3, ESP32-C6, ESP32-S3 and ESP32-H2 chips"
-        );
-    }
 }

--- a/build.rs
+++ b/build.rs
@@ -14,4 +14,11 @@ fn main() {
         1 => {}
         n => panic!("Exactly 1 chip must be enabled via its Cargo feature, {n} provided"),
     };
+
+    // Ensure that exactly a backend is selected
+    let backend = [cfg!(feature = "println"), cfg!(feature = "defmt")];
+
+    if backend.iter().filter(|&&f| f).count() == 0 {
+        panic!("A backend needs to be selected");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 #![no_std]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
-#![cfg_attr(feature = "defmt", feature(panic_info_message))]
 #![allow(rustdoc::bare_urls)]
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
 #[cfg(feature = "defmt")]
 use defmt as _;
+#[cfg(feature = "println")]
 use esp_println as _;
 
 const MAX_BACKTRACE_ADDRESSES: usize = 10;
@@ -26,7 +26,7 @@ macro_rules! println {
     };
 }
 
-#[cfg(not(feature = "defmt"))]
+#[cfg(all(feature = "println", not(feature = "defmt")))]
 macro_rules! println {
     ($($arg:tt)*) => {
         esp_println::println!($($arg)*);
@@ -35,7 +35,7 @@ macro_rules! println {
 
 #[allow(unused, unused_variables)]
 fn set_color_code(code: &str) {
-    #[cfg(not(feature = "defmt"))]
+    #[cfg(feature = "println")]
     {
         println!("{}", code);
     }
@@ -70,13 +70,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     println!("{:#?}", info);
 
     #[cfg(feature = "defmt")]
-    {
-        if let Some(args) = info.message() {
-            println!("Panic message: {:?}", defmt::Display2Format(args));
-        } else {
-            println!("Panic message is not available");
-        }
-    }
+    println!("{:#?}", defmt::Display2Format(info));
 
     println!("");
     println!("Backtrace:");

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -1,12 +1,12 @@
 use core::arch::asm;
-use defmt::Format;
 
 use crate::MAX_BACKTRACE_ADDRESSES;
 
 /// Registers saved in trap handler
 #[doc(hidden)]
 #[allow(missing_docs)]
-#[derive(Default, Clone, Copy, Format)]
+#[derive(Default, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(C)]
 pub(crate) struct TrapFrame {
     pub ra: usize,

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -1,6 +1,5 @@
-use core::arch::asm;
-
 use crate::MAX_BACKTRACE_ADDRESSES;
+use core::arch::asm;
 
 /// Registers saved in trap handler
 #[doc(hidden)]

--- a/src/xtensa.rs
+++ b/src/xtensa.rs
@@ -1,10 +1,10 @@
 use crate::MAX_BACKTRACE_ADDRESSES;
 use core::arch::asm;
-use defmt::Format;
 
 #[doc(hidden)]
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Copy, Format)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(C)]
 pub enum ExceptionCause {
     /// Illegal Instruction
@@ -93,7 +93,8 @@ pub enum ExceptionCause {
 
 #[doc(hidden)]
 #[allow(missing_docs, non_snake_case)]
-#[derive(Clone, Copy, Format)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(C)]
 pub struct Context {
     pub PC: u32,


### PR DESCRIPTION
Fixes #45

As mentioned in #46 it doesn't make sense to activate `esp-println` features via `esp-backtrace` features. So `print-XXX` is removed - the user needs to activate the desired communication method _only_ on `esp-println`

The `defmt-espflash` feature is now renamed to `defmt` since we don't activate the corresponding feature in `esp-println` anymore (already since #46)

As a bonus this should make the docs a bit more interesting

The changes to the features will unfortunately make the next release a major update
