### PR TITLE
Version 0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-backtrace"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Bare-metal backtrace support for ESP32"
 repository = "https://github.com/esp-rs/esp-backtrace"
@@ -11,8 +11,8 @@ default-target = "riscv32imc-unknown-none-elf"
 features = ["esp32c3", "panic-handler", "exception-handler", "println", "esp-println/uart"]
 
 [dependencies]
-esp-println = { version = "0.9.0", optional = true, default-features = false }
-defmt = { version = "=0.3.5", optional = true }
+esp-println = { version = "0.9.1", optional = true, default-features = false }
+defmt = { version = "0.3.6", optional = true }
 
 [features]
 default = [ "colors" ]

--- a/README.md
+++ b/README.md
@@ -11,24 +11,29 @@ When using the panic and/or exception handler make sure to include `use esp_back
 
 ## Features
 
-| Feature           | Description                                                          |
-| ----------------- | -------------------------------------------------------------------- |
-| esp32             | Target ESP32                                                         |
-| esp32c2           | Target ESP32-C2                                                      |
-| esp32c3           | Target ESP32-C3                                                      |
-| esp32c6           | Target ESP32-C6                                                      |
-| esp32h2           | Target ESP32-H2                                                      |
-| esp32p4           | Target ESP32-P4                                                      |
-| esp32s2           | Target ESP32-S2                                                      |
-| esp32s3           | Target ESP32-S3                                                      |
-| panic-handler     | Include a panic handler, will add `esp-println` as a dependency      |
-| exception-handler | Include an exception handler, will add `esp-println` as a dependency |
-| println           | Use `esp-println` to print messages                                  |
-| defmt             | Use `defmt` logging to print messages\* (check [example](https://github.com/playfulFence/backtrace-defmt-example))                    |
-| colors            | Print messages in red\*                                              |
-| halt-cores        | Halt both CPUs on ESP32 / ESP32-S3 in case of a panic or exception   |
+| Feature           | Description                                                                                                        |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------ |
+| esp32             | Target ESP32                                                                                                       |
+| esp32c2           | Target ESP32-C2                                                                                                    |
+| esp32c3           | Target ESP32-C3                                                                                                    |
+| esp32c6           | Target ESP32-C6                                                                                                    |
+| esp32h2           | Target ESP32-H2                                                                                                    |
+| esp32p4           | Target ESP32-P4                                                                                                    |
+| esp32s2           | Target ESP32-S2                                                                                                    |
+| esp32s3           | Target ESP32-S3                                                                                                    |
+| panic-handler     | Include a panic handler, will add `esp-println` as a dependency                                                    |
+| exception-handler | Include an exception handler, will add `esp-println` as a dependency                                               |
+| println           | Use `esp-println` to print messages                                                                                |
+| defmt             | Use `defmt` logging to print messages\* (check [example](https://github.com/playfulFence/backtrace-defmt-example)) |
+| colors            | Print messages in red\*                                                                                            |
+| halt-cores        | Halt both CPUs on ESP32 / ESP32-S3 in case of a panic or exception                                                 |
 
 \* _only used for panic and exception handlers_
+
+### `defmt` Feature
+
+Please note that `defmt` does _not_ provide MSRV guarantees with releases, and as such we are not able to make any MSRV guarantees when this feature is enabled. For more information refer to the MSRV section of `defmt`'s README:
+https://github.com/knurling-rs/defmt?tab=readme-ov-file#msrv
 
 ## License
 


### PR DESCRIPTION
- Un-pins the `defmt` version
- Mention lack of MSRV guarantees when using `defmt` feature in `README.md`