### PR TITLE
Add Custom halt feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ exception-handler = []
 panic-handler = []
 halt-cores = []
 colors = []
+custom-halt = []
+
+[lints.rust]
+unexpected_cfgs = "allow"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When using the panic and/or exception handler make sure to include `use esp_back
 ## Features
 
 | Feature           | Description                                                                                                        |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------ |
+|-------------------|--------------------------------------------------------------------------------------------------------------------|
 | esp32             | Target ESP32                                                                                                       |
 | esp32c2           | Target ESP32-C2                                                                                                    |
 | esp32c3           | Target ESP32-C3                                                                                                    |
@@ -26,8 +26,9 @@ When using the panic and/or exception handler make sure to include `use esp_back
 | println           | Use `esp-println` to print messages                                                                                |
 | defmt             | Use `defmt` logging to print messages\* (check [example](https://github.com/playfulFence/backtrace-defmt-example)) |
 | colors            | Print messages in red\*                                                                                            |
-| halt-cores        | Halt both CPUs on ESP32 / ESP32-S3 in case of a panic or exception                                                 |
+| halt-cores        | Halt both CPUs on ESP32 / ESP32-S3 instead of doing a `loop {}` in case of a panic or exception                    |
 | semihosting       | Call `semihosting::process::abort()` on panic.                                                                     |
+| custom-halt       | Invoke the extern function `custom_halt()` instead of doing a `loop {}` in case of a panic or exception            |
 
 \* _only used for panic and exception handlers_
 

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,10 @@ fn main() {
         panic!("A backend needs to be selected");
     }
 
+    if cfg!(feature = "custom-halt") && cfg!(feature = "halt-cores") {
+        panic!("Only one of `custom-halt` and `halt-cores` can be enabled");
+    }
+
     if is_nightly() {
         println!("cargo:rustc-cfg=nightly");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ fn exception_handler(context: &arch::TrapFrame) -> ! {
             if let Some(addr) = e {
                 #[cfg(all(feature = "colors", feature = "println"))]
                 println!("{}0x{:x}", RED, addr - crate::arch::RA_OFFSET);
-    
+
                 #[cfg(not(all(feature = "colors", feature = "println")))]
                 println!("0x{:x}", addr - crate::arch::RA_OFFSET);
             }
@@ -279,13 +279,23 @@ fn is_valid_ram_address(address: u32) -> bool {
     true
 }
 
-#[cfg(any(
-    not(any(feature = "esp32", feature = "esp32p4", feature = "esp32s3")),
-    not(feature = "halt-cores")
+#[cfg(all(
+    any(
+        not(any(feature = "esp32", feature = "esp32p4", feature = "esp32s3")),
+        not(feature = "halt-cores")
+    ),
+    not(feature = "custom-halt")
 ))]
 #[allow(unused)]
 fn halt() -> ! {
     loop {}
+}
+#[cfg(feature = "custom-halt")]
+fn halt() -> ! {
+    extern "Rust" {
+        fn custom_halt() -> !;
+    }
+    unsafe { custom_halt() }
 }
 
 // TODO: Enable `halt` function for `esp32p4` feature once implemented


### PR DESCRIPTION
This allows me to implement esp-rs/esp-hal#1586 or do custom stuff like flushing logs etc...

I know that for using esp-backtrace in an production environment, we probably want to refactor/extend in a different direction, but at least this allows for hacking stuff during development without duplicating and adapting the entire panic handler.